### PR TITLE
Add better hide-options-checkbox functionality

### DIFF
--- a/admin/options/fields/checkbox_hide_all/field_checkbox_hide_all.js
+++ b/admin/options/fields/checkbox_hide_all/field_checkbox_hide_all.js
@@ -1,0 +1,13 @@
+jQuery(document).ready(function(){
+	
+	jQuery('.redux-opts-checkbox-hide-all').each(function(){
+		if(!jQuery(this).is(':checked')){
+			jQuery(this).closest('tr').nextAll('tr').hide();
+		}
+	});
+	
+	jQuery('.redux-opts-checkbox-hide-all').click(function(){
+			jQuery(this).closest('tr').nextAll('tr').fadeToggle('slow');
+	});
+	
+});

--- a/admin/options/fields/checkbox_hide_all/field_checkbox_hide_all.php
+++ b/admin/options/fields/checkbox_hide_all/field_checkbox_hide_all.php
@@ -1,0 +1,48 @@
+<?php
+class Redux_Options_checkbox_hide_all extends Redux_Options {
+
+    /**
+     * Field Constructor.
+     *
+     * Required - must call the parent constructor, then assign field and value to vars, and obviously call the render field function
+     *
+     * @since Redux_Options 1.0.0
+    */
+    function __construct($field = array(), $value ='', $parent) {
+        parent::__construct($parent->sections, $parent->args, $parent->extra_tabs);
+        $this->field = $field;
+        $this->value = $value;
+        //$this->render();
+    }
+
+    /**
+     * Field Render Function.
+     *
+     * Takes the vars and outputs the HTML for the field in the settings
+     *
+     * @since Redux_Options 1.0.0
+    */
+    function render() {
+        $class = (isset($this->field['class'])) ? $this->field['class'] : '';
+        echo ($this->field['desc'] != '') ? ' <label for="' . $this->field['id'] . '">' : '';
+        echo '<input type="checkbox" id="' . $this->field['id'] . '" name="' . $this->args['opt_name'] . '[' . $this->field['id'] . ']" value="1" class="' . $class . ' redux-opts-checkbox-hide-all" ' . checked($this->value, '1', false) . ' />';
+        echo (isset($this->field['desc']) && !empty($this->field['desc'])) ? ' ' . $this->field['desc'] . '</label>' : '';
+    }
+
+    /**
+     * Enqueue Function.
+     *
+     * If this field requires any scripts, or css define this function and register/enqueue the scripts/css
+     *
+     * @since Redux_Options 1.0.0
+    */
+    function enqueue() {
+        wp_enqueue_script(
+            'redux-opts-checkbox-hide-all-js', 
+            Redux_OPTIONS_URL . 'fields/checkbox_hide_all/field_checkbox_hide_all.js', 
+            array('jquery'),
+            time(),
+            true
+        );
+    }
+}


### PR DESCRIPTION
So far the framework can only hide one options, Redux_Options_checkbox_hide_below uses:

```
jQuery(this).closest('tr').next('tr').hide();
```

to hide the next option.

It would be optimal if we could add the id of the checkbox to items we would like to hide, but that would would need more of a rewrite.

This is just one extra option that hides everything below Redux_Options_checkbox_hide_all. A placeholder for something better later.
