### PR TITLE
WP 3.5 media manager for the upload option

### DIFF
--- a/admin/options/fields/upload/field_upload.js
+++ b/admin/options/fields/upload/field_upload.js
@@ -1,49 +1,64 @@
 /*global jQuery, document, redux_upload, formfield:true, preview:true, tb_show, window, imgurl:true, tb_remove, $relid:true*/
-jQuery(document).ready(function () {
-    "use strict";
+/*
+This is the uploader for wordpress starting from version 3.5
+*/
+jQuery(document).ready(function(){
 
-    /*
-     *
-     * Redux_Options_upload function
-     * Adds media upload functionality to the page
-     *
-     */
+            jQuery(".redux-opts-upload").click( function( event ) {
+ 
+                var relid = jQuery(this).attr('rel-id');
 
-    var header_clicked = false;
+                event.preventDefault();
 
-    jQuery("img[src='']").attr("src", redux_upload.url);
+                // If the media frame already exists, reopen it.
+                if ( typeof(custom_file_frame)!=="undefined" ) {
+                    custom_file_frame.open();
+                    return;
+                }
 
-    jQuery('.redux-opts-upload').click(function () {
-        header_clicked = true;
-        formfield = jQuery(this).attr('rel-id');
-        preview = jQuery(this).prev('img');
-        tb_show('', 'media-upload.php?type=image&amp;post_id=0&amp;TB_iframe=true');
-        return false;
-    });
+                // Create the media frame.
+                custom_file_frame = wp.media.frames.customHeader = wp.media({
+                    // Set the title of the modal.
+                    title: jQuery(this).data("choose"),
 
-    jQuery('.redux-opts-upload-remove').click(function () {
-        $relid = jQuery(this).attr('rel-id');
-        jQuery('#' + $relid).val('');
+                    // Tell the modal to show only images. Ignore if want ALL
+                    library: {
+                        type: 'image'
+                    },
+                    // Customize the submit button.
+                    button: {
+                        // Set the text of the button.
+                        text: jQuery(this).data("update")
+                    }
+                });
+
+                custom_file_frame.on( "select", function() {
+                    // Grab the selected attachment.
+                    var attachment = custom_file_frame.state().get("selection").first();
+
+                    // Update value of the targetfield input with the attachment url.
+                    jQuery('.redux-opts-screenshot').attr('src', attachment.attributes.url);
+                    jQuery('#' + relid ).val(attachment.attributes.url);
+
+                    jQuery('.redux-opts-upload').hide();
+                    jQuery('.redux-opts-screenshot').show();
+                    jQuery('.redux-opts-upload-remove').show();
+            });
+
+            custom_file_frame.open();
+        });
+
+    jQuery(".redux-opts-upload-remove").click( function( event ) {
+
+        var relid = jQuery(this).attr('rel-id');
+        console.log("hahaha");
+
+        event.preventDefault();
+
+        jQuery('#' + relid).val('');
         jQuery(this).prev().fadeIn('slow');
-        jQuery(this).prev().prev().fadeOut('slow', function () { jQuery(this).attr("src", redux_upload.url); });
+        jQuery('.redux-opts-screenshot').fadeOut('slow');
         jQuery(this).fadeOut('slow');
     });
 
-    // Store original function
-    window.original_send_to_editor = window.send_to_editor;
-
-    window.send_to_editor = function (html) {
-        if (header_clicked) {
-            imgurl = jQuery('img', html).attr('src');
-            jQuery('#' + formfield).val(imgurl);
-            jQuery('#' + formfield).next().fadeIn('slow');
-            jQuery('#' + formfield).next().next().fadeOut('slow');
-            jQuery('#' + formfield).next().next().next().fadeIn('slow');
-            jQuery(preview).attr('src', imgurl);
-            tb_remove();
-            header_clicked = false;
-        } else {
-            window.original_send_to_editor(html);
-        }
-    }
 });

--- a/admin/options/fields/upload/field_upload.php
+++ b/admin/options/fields/upload/field_upload.php
@@ -22,11 +22,11 @@ class Redux_Options_upload extends Redux_Options {
      * @since Redux_Options 1.0.0
     */
     function render() {
-        $class = (isset($this->field['class'])) ? $this->field['class'] : 'regular-text';
+        $class = (isset($this->field['class'])) ? $this->field['class'] : 'regular-text';        
         echo '<input type="hidden" id="' . $this->field['id'] . '" name="' . $this->args['opt_name'] . '[' . $this->field['id'] . ']" value="' . $this->value . '" class="' . $class . '" />';
         echo '<img class="redux-opts-screenshot" id="redux-opts-screenshot-' . $this->field['id'] . '" src="' . $this->value . '" />';
-        if($this->value == '') { $remove = ' style="display:none;"'; $upload = ''; } else { $remove = ''; $upload = ' style="display:none;"'; }
-        echo ' <a href="javascript:void(0);" class="redux-opts-upload button-secondary"' . $upload . ' rel-id="' . $this->field['id'] . '">' . __('Upload', Redux_TEXT_DOMAIN) . '</a>';
+        if($this->value == '') {$remove = ' style="display:none;"'; $upload = ''; } else {$remove = ''; $upload = ' style="display:none;"'; }
+        echo ' <a data-update="Select File" data-choose="Choose a File" href="javascript:void(0);"class="redux-opts-upload button-secondary"' . $upload . ' rel-id="' . $this->field['id'] . '">' . __('Upload', Redux_TEXT_DOMAIN) . '</a>';
         echo ' <a href="javascript:void(0);" class="redux-opts-upload-remove"' . $remove . ' rel-id="' . $this->field['id'] . '">' . __('Remove Upload', Redux_TEXT_DOMAIN) . '</a>';
         echo (isset($this->field['desc']) && !empty($this->field['desc'])) ? '<br/><span class="description">' . $this->field['desc'] . '</span>' : '';
     }
@@ -39,14 +39,28 @@ class Redux_Options_upload extends Redux_Options {
      * @since Redux_Options 1.0.0
     */
     function enqueue() {
-        wp_enqueue_script(
-            'redux-opts-field-upload-js', 
-            Redux_OPTIONS_URL . 'fields/upload/field_upload.js', 
-            array('jquery', 'thickbox', 'media-upload'),
-            time(),
-            true
-        );
-        wp_enqueue_style('thickbox');// thanks to https://github.com/rzepak
+    //         global $wp_version; //AP: why doesn't this work?!?!
+            $wp_version = floatval(get_bloginfo('version'));
+
+        if ( $wp_version < "3.5" ) {
+            wp_enqueue_script(
+                'redux-opts-field-upload-js_3_4', 
+                Redux_OPTIONS_URL . 'fields/upload/field_upload_3_4.js', 
+                array('jquery', 'thickbox', 'media-upload'),
+                time(),
+                true
+            );
+            wp_enqueue_style('thickbox');// thanks to https://github.com/rzepak
+        } else {
+            wp_enqueue_script(
+                'redux-opts-field-upload-js_3_4', 
+                Redux_OPTIONS_URL . 'fields/upload/field_upload.js', 
+                array('jquery'),
+                time(),
+                true
+            );
+            wp_enqueue_media();
+        }
         wp_localize_script('redux-opts-field-upload-js', 'redux_upload', array('url' => $this->url.'fields/upload/blank.png'));
     }
 }

--- a/admin/options/fields/upload/field_upload_3_4.js
+++ b/admin/options/fields/upload/field_upload_3_4.js
@@ -1,0 +1,52 @@
+/*global jQuery, document, redux_upload, formfield:true, preview:true, tb_show, window, imgurl:true, tb_remove, $relid:true*/
+/*
+This is the uploader for wordpress before version 3.5
+*/
+jQuery(document).ready(function () {
+    "use strict";
+
+    /*
+     *
+     * Redux_Options_upload function
+     * Adds media upload functionality to the page
+     *
+     */
+
+    var header_clicked = false;
+
+    jQuery("img[src='']").attr("src", redux_upload.url);
+
+    jQuery('.redux-opts-upload').click(function () {
+        header_clicked = true;
+        formfield = jQuery(this).attr('rel-id');
+        preview = jQuery(this).prev('img');
+        tb_show('', 'media-upload.php?type=image&amp;post_id=0&amp;TB_iframe=true');
+        return false;
+    });
+
+    jQuery('.redux-opts-upload-remove').click(function () {
+        $relid = jQuery(this).attr('rel-id');
+        jQuery('#' + $relid).val('');
+        jQuery(this).prev().fadeIn('slow');
+        jQuery(this).prev().prev().fadeOut('slow', function () { jQuery(this).attr("src", redux_upload.url); });
+        jQuery(this).fadeOut('slow');
+    });
+
+    // Store original function
+    window.original_send_to_editor = window.send_to_editor;
+
+    window.send_to_editor = function (html) {
+        if (header_clicked) {
+            imgurl = jQuery('img', html).attr('src');
+            jQuery('#' + formfield).val(imgurl);
+            jQuery('#' + formfield).next().fadeIn('slow');
+            jQuery('#' + formfield).next().next().fadeOut('slow');
+            jQuery('#' + formfield).next().next().next().fadeIn('slow');
+            jQuery(preview).attr('src', imgurl);
+            tb_remove();
+            header_clicked = false;
+        } else {
+            window.original_send_to_editor(html);
+        }
+    }
+});


### PR DESCRIPTION
WP 3.5 media manager + fall-back for older version (did not test the old version, it is just the old code that was there, no changes, just renamed the js file)
