### PR TITLE
Redux_Options_editor. Check if 'autop' field key isn't set

### DIFF
--- a/admin/options/fields/editor/field_editor.php
+++ b/admin/options/fields/editor/field_editor.php
@@ -28,7 +28,7 @@ class Redux_Options_editor extends Redux_Options {
         $settings = array(
             'textarea_name' => $this->args['opt_name'] . '[' . $this->field['id'] . ']',
             'editor_class' => $class,
-            'wpautop' => ($this->field['autop'] == false ? 'false' : 'true')
+            'wpautop' => (isset($this->field['autop'])) ? $this->field['autop'] : 'true'
         );
         wp_editor($this->value, $this->field['id'], $settings );
         echo (isset($this->field['desc']) && !empty($this->field['desc'])) ? '<br/><span class="description">' . $this->field['desc'] . '</span>' : '';


### PR DESCRIPTION
Check if the value of array key 'wpautop' is null.
