### PR TITLE
Created filters redux-opts-validateclass-load and

### DIFF
--- a/options/defaults.php
+++ b/options/defaults.php
@@ -319,7 +319,9 @@ if(!class_exists('Redux_Options') ){
                         if(isset($field['type'])) {
                             $field_class = 'Redux_Options_' . $field['type'];
                             if(!class_exists($field_class)) {
-                                require_once($this->dir . 'fields/' . $field['type'] . '/field_' . $field['type'] . '.php');
+                                $class_file = apply_filters('redux-opts-typeclass-load', $field_class, $this->dir . 'fields/' . $field['type'] . '/field_' . $field['type'] . '.php');
+                                if ( $class_file )
+                                    require_once($class_file);
                             }
 
                             if(class_exists($field_class) && method_exists($field_class, 'enqueue')) {
@@ -513,11 +515,13 @@ if(!class_exists('Redux_Options') ){
 
                         if(isset($field['validate'])) {
                             $validate = 'Redux_Validation_' . $field['validate'];
-            
-                            if(!class_exists($validate)) {
-                                require_once($this->dir . 'validation/' . $field['validate'] . '/validation_' . $field['validate'] . '.php');
-                            }
 
+                            if(!class_exists($validate)) {
+                                $class_file = apply_filters('redux-opts-validateclass-load', $validate, $this->dir . 'validation/' . $field['validate'] . '/validation_' . $field['validate'] . '.php');
+                                if ( $class_file )
+                                    require_once($class_file);
+                            }
+            
                             if(class_exists($validate)) {
                                 $validation = new $validate($field, $plugin_options[$field['id']], $options[$field['id']]);
                                 $plugin_options[$field['id']] = $validation->value;
@@ -830,7 +834,9 @@ if(!class_exists('Redux_Options') ){
                 $field_class = 'Redux_Options_'.$field['type'];
 
                 if(class_exists($field_class)) {
-                    require_once($this->dir . 'fields/' . $field['type'] . '/field_' . $field['type'] . '.php');
+                    $class_file = apply_filters('redux-opts-typeclass-load', $field_class, $this->dir . 'fields/' . $field['type'] . '/field_' . $field['type'] . '.php');
+                    if ( $class_file )
+                        require_once($class_file);
                 }
 
                 if(class_exists($field_class)) {


### PR DESCRIPTION
Created filters redux-opts-validateclass-load and redux-opts-typeclass-load in order to load fields and validation classes outside the redux folder structure, this way developers can add their own custom fields and validation classes and not loose their changes when the framework files are updated.

Example use:

``` php
add_filter('redux-opts-typeclass-load', 'signob_custom_fields', 10, 2);
    function signob_custom_fields($class, $file) {

        switch ($class) {
            case 'Redux_Options_role_select':
                return ABSPATH . 'wp-content/fields/role_select/field_role_select.php';
                break;

        }

    //To cancel loading class, return false
    return $file;

    } //function
//action
```
