### PR TITLE
Better handling of std values and fix bug in pull request # 48

### DIFF
--- a/options/defaults.php
+++ b/options/defaults.php
@@ -139,6 +139,9 @@ if(!class_exists('Redux_Options') ){
         */
         function _default_values() {        
             $defaults = array();
+
+            if ( is_null($this->sections) )
+                return;
         
             foreach($this->sections as $k => $section) {
                 if(isset($section['fields'])) {
@@ -409,6 +412,9 @@ if(!class_exists('Redux_Options') ){
         */
         function _register_setting() {
             register_setting($this->args['opt_name'] . '_group', $this->args['opt_name'], array(&$this,'_validate_options'));
+
+            if ( is_null($this->sections))
+                return;
 
             foreach($this->sections as $k => $section) {
                 add_settings_section($this->args['opt_name'] . $k . '_section', $section['title'], array(&$this, '_section_desc'), $this->args['opt_name'] . $k . '_section_group');

--- a/options/defaults.php
+++ b/options/defaults.php
@@ -100,11 +100,13 @@ if(!class_exists('Redux_Options') ){
          *
          * @since Redux_Options 1.0.1
          * @param string $opt_name: option name to return
-         * @param mixed $default (null): value to return if option not set
+         * @param mixed $default (null): value to return if std not set
         */
         function _get_std($opt_name, $default = null) {
             if ($this->args['std_show'] == true ) {
-                if ( is_null($this->options_defaults) ) $this->_default_values(); // fill cache
+                if ( is_null($this->options_defaults) ) 
+                    $this->_default_values(); // fill cache
+
                 $default = array_key_exists($opt_name, $this->options_defaults) ? $this->options_defaults[$opt_name] : $default;
             }
             return $default;
@@ -119,16 +121,6 @@ if(!class_exists('Redux_Options') ){
         */
         function get($opt_name, $default = null) {
             return ( !empty($this->options[$opt_name]) ) ? $this->options[$opt_name] : $this->_get_std($opt_name, $default);
-/*
-
-            if ( is_null($this->options_defaults) ) _default_values(); // fill cache
-            //if std_show set $default to std value, return orig. $default only if there is no std set 
-            $default = ( $this->args['std_show'] == true && array_key_exists($opt_name, $this->options_defaults)
-
-                isset($this->options_defaults[$opt_name]) ) ? $defaults[$opt_name] : $default;
-            echo $opt_name . ': ' . ( isset($defaults[$opt_name]) ? 'set' : 'not set'); 
-            return (!empty($this->options[$opt_name])) ? $this->options[$opt_name] : $default;
-  */
         }
     
         /**
@@ -153,11 +145,10 @@ if(!class_exists('Redux_Options') ){
         */
         function show($opt_name, $default = '') {
             $option = $this->get($opt_name);
-            if(!is_array($option) && $option != '') {
+            if( !is_array($option) && $option != '' ) 
                 echo $option;
-            } elseif($default != '') {
-                echo $default;
-            }
+            elseif($default != '') 
+                echo $this->_get_std($opt_name, $default);
         }
 
         /**
@@ -166,10 +157,7 @@ if(!class_exists('Redux_Options') ){
          * @since Redux_Options 1.0.0
         */
         function _default_values() {        
-            if ( is_null($this->sections) ) 
-                return array(); // return empty array 
-
-            if ( is_null($this->options_defaults) ) {
+            if ( !is_null($this->sections) && is_null($this->options_defaults) ) {
                 // fill the cache
                 foreach($this->sections as $section) {
                     if(isset($section['fields'])) {
@@ -846,7 +834,7 @@ if(!class_exists('Redux_Options') ){
         /**
          * Field HTML OUTPUT.
          *
-         * Gets option from options array, then calls the speicfic field type class - allows extending by other devs
+         * Gets option from options array, then calls the specific field type class - allows extending by other devs
          * @since Redux_Options 1.0.0
         */
         function _field_input($field) {
@@ -868,13 +856,7 @@ if(!class_exists('Redux_Options') ){
                 }
 
                 if(class_exists($field_class)) {
-                    $value = $this->get($field['std'], '');
-                    /*
-                    if ( !isset($this->options[$field['id']]) && $this->args['std_show'] == true && isset($field['std']) )
-                        $value = $field['std'];
-                    else
-                        $value = (isset($this->options[$field['id']])) ? $this->options[$field['id']] : '';
-                    */
+                    $value = $this->get($field['id'], '');
                     do_action('redux-opts-before-field-' . $this->args['opt_name'], $field, $value);
                     $render = '';
                     $render = new $field_class($field, $value, $this);

--- a/options/defaults.php
+++ b/options/defaults.php
@@ -57,6 +57,10 @@ if(!class_exists('Redux_Options') ){
             $defaults['help_tabs'] = array();
             $defaults['help_sidebar'] = __('', Redux_TEXT_DOMAIN);
 
+            //The defaults are set so it will preserve the old behaviour.
+            $defaults['std_show'] = false;  // if true, it shows the std value (if std is set)
+            $defaults['std_mark'] = ''; //What to print by the field's title if the value shown is the std
+
             // Get args
             $this->args = wp_parse_args($args, $defaults);
             $this->args = apply_filters('redux-opts-args-'.$this->args['opt_name'], $this->args);
@@ -147,7 +151,6 @@ if(!class_exists('Redux_Options') ){
 
             return $defaults;
         }
-    	
     
         /**
          * Set default options on admin_init if option doesn't exist
@@ -155,24 +158,11 @@ if(!class_exists('Redux_Options') ){
          * @since Redux_Options 1.0.0
         */
         function _set_default_options() {
-	        $defaults = array();
-	        $this->options = get_option($this->args['opt_name']);
-			
-	        foreach($this->sections as $k => $section) {
-                if(isset($section['fields'])) {
-                    foreach($section['fields'] as $fieldk => $field) {
-                        if(!isset($field['std'])){ $field['std'] = ''; }
-                        if(!isset($this->options[$field['id']]))
-                            $defaults[$field['id']] = $field['std'];
-                        else
-                            $defaults[$field['id']] = $this->options[$field['id']];
-                    }
-                }
-             }
-
-             update_option($this->args['opt_name'], $defaults);
-             $this->options = get_option($this->args['opt_name']);
-         }
+            if(!get_option($this->args['opt_name'])) {
+                add_option($this->args['opt_name'], $this->_default_values());
+            }
+            $this->options = get_option($this->args['opt_name']);
+        }
 
         /**
          * Class Options Page Function, creates main options page.
@@ -319,7 +309,7 @@ if(!class_exists('Redux_Options') ){
                         if(isset($field['type'])) {
                             $field_class = 'Redux_Options_' . $field['type'];
                             if(!class_exists($field_class)) {
-                                $class_file = apply_filters('redux-opts-typeclass-load', $field_class, $this->dir . 'fields/' . $field['type'] . '/field_' . $field['type'] . '.php');
+                                $class_file = apply_filters('redux-opts-typeclass-load', $this->dir . 'fields/' . $field['type'] . '/field_' . $field['type'] . '.php', $field_class);
                                 if ( $class_file )
                                     require_once($class_file);
                             }
@@ -426,10 +416,13 @@ if(!class_exists('Redux_Options') ){
                 if(isset($section['fields'])) {
                     foreach($section['fields'] as $fieldk => $field) {
                         if(isset($field['title'])) {
-                            $th = (isset($field['sub_desc'])) ? $field['title'] . '<span class="description">' . $field['sub_desc'] . '</span>' : $field['title'];
+                            $std_mark = ( !isset($this->options[$field['id']]) && $this->args['std_show'] == true && isset($field['std']) ) ? $this->args['std_mark'] : '';
+                            $th = $field['title'] . $std_mark;
+                            if (isset($field['sub_desc']))
+                                $th .= '<span class="description">' . $field['sub_desc'] . '</span>';
                         } else {
                             $th = '';
-                        }
+                        }                        
                     
                         add_settings_field($fieldk . '_field', $th, array(&$this,'_field_input'), $this->args['opt_name'] . $k . '_section_group', $this->args['opt_name'] . $k . '_section', $field); // checkbox
                     }
@@ -517,7 +510,7 @@ if(!class_exists('Redux_Options') ){
                             $validate = 'Redux_Validation_' . $field['validate'];
 
                             if(!class_exists($validate)) {
-                                $class_file = apply_filters('redux-opts-validateclass-load', $validate, $this->dir . 'validation/' . $field['validate'] . '/validation_' . $field['validate'] . '.php');
+                                $class_file = apply_filters('redux-opts-validateclass-load', $this->dir . 'validation/' . $field['validate'] . '/validation_' . $field['validate'] . '.php', $validate);
                                 if ( $class_file )
                                     require_once($class_file);
                             }
@@ -834,13 +827,17 @@ if(!class_exists('Redux_Options') ){
                 $field_class = 'Redux_Options_'.$field['type'];
 
                 if(class_exists($field_class)) {
-                    $class_file = apply_filters('redux-opts-typeclass-load', $field_class, $this->dir . 'fields/' . $field['type'] . '/field_' . $field['type'] . '.php');
+                    $class_file = apply_filters('redux-opts-typeclass-load', $this->dir . 'fields/' . $field['type'] . '/field_' . $field['type'] . '.php', $field_class);
                     if ( $class_file )
                         require_once($class_file);
                 }
 
                 if(class_exists($field_class)) {
-                    $value = (isset($this->options[$field['id']])) ? $this->options[$field['id']] : '';
+                    if ( !isset($this->options[$field['id']]) && $this->args['std_show'] == true && isset($field['std']) )
+                        $value = $field['std'];
+                    else
+                        $value = (isset($this->options[$field['id']])) ? $this->options[$field['id']] : '';
+
                     do_action('redux-opts-before-field-' . $this->args['opt_name'], $field, $value);
                     $render = '';
                     $render = new $field_class($field, $value, $this);

--- a/options/defaults.php
+++ b/options/defaults.php
@@ -27,6 +27,7 @@ if(!class_exists('Redux_Options') ){
         public $errors = array();
         public $warnings = array();
         public $options = array();
+        public $options_defaults = null;
 
         /**
          * Class Constructor. Defines the args for the theme options class
@@ -93,14 +94,41 @@ if(!class_exists('Redux_Options') ){
             $this->options = get_option($this->args['opt_name']);
         }    
 
+
+        /**
+         * This is used to return the std value if std_show is set
+         *
+         * @since Redux_Options 1.0.1
+         * @param string $opt_name: option name to return
+         * @param mixed $default (null): value to return if option not set
+        */
+        function _get_std($opt_name, $default = null) {
+            if ($this->args['std_show'] == true ) {
+                if ( is_null($this->options_defaults) ) $this->_default_values(); // fill cache
+                $default = array_key_exists($opt_name, $this->options_defaults) ? $this->options_defaults[$opt_name] : $default;
+            }
+            return $default;
+        }
+
         /**
          * ->get(); This is used to return and option value from the options array
          *
          * @since Redux_Options 1.0.0
-         * @param $array $args Arguments. Class constructor arguments.
+         * @param string $opt_name: option name to return
+         * @param mixed $default (null): value to return if option not set
         */
         function get($opt_name, $default = null) {
+            return ( !empty($this->options[$opt_name]) ) ? $this->options[$opt_name] : $this->_get_std($opt_name, $default);
+/*
+
+            if ( is_null($this->options_defaults) ) _default_values(); // fill cache
+            //if std_show set $default to std value, return orig. $default only if there is no std set 
+            $default = ( $this->args['std_show'] == true && array_key_exists($opt_name, $this->options_defaults)
+
+                isset($this->options_defaults[$opt_name]) ) ? $defaults[$opt_name] : $default;
+            echo $opt_name . ': ' . ( isset($defaults[$opt_name]) ? 'set' : 'not set'); 
             return (!empty($this->options[$opt_name])) ? $this->options[$opt_name] : $default;
+  */
         }
     
         /**
@@ -138,21 +166,22 @@ if(!class_exists('Redux_Options') ){
          * @since Redux_Options 1.0.0
         */
         function _default_values() {        
-            $defaults = array();
+            if ( is_null($this->sections) ) 
+                return array(); // return empty array 
 
-            if ( is_null($this->sections) )
-                return;
-        
-            foreach($this->sections as $k => $section) {
-                if(isset($section['fields'])) {
-                    foreach($section['fields'] as $fieldk => $field) {
-                        if(!isset($field['std'])){ $field['std'] = ''; }
-                        $defaults[$field['id']] = $field['std'];
+            if ( is_null($this->options_defaults) ) {
+                // fill the cache
+                foreach($this->sections as $section) {
+                    if(isset($section['fields'])) {
+                        foreach($section['fields'] as $field) {
+                            if( isset($field['std']) ) 
+                                $this->options_defaults[$field['id']] = $field['std'];
+                        }
                     }
                 }
             }
 
-            return $defaults;
+            return $this->options_defaults;
         }
     
         /**
@@ -839,11 +868,13 @@ if(!class_exists('Redux_Options') ){
                 }
 
                 if(class_exists($field_class)) {
+                    $value = $this->get($field['std'], '');
+                    /*
                     if ( !isset($this->options[$field['id']]) && $this->args['std_show'] == true && isset($field['std']) )
                         $value = $field['std'];
                     else
                         $value = (isset($this->options[$field['id']])) ? $this->options[$field['id']] : '';
-
+                    */
                     do_action('redux-opts-before-field-' . $this->args['opt_name'], $field, $value);
                     $render = '';
                     $render = new $field_class($field, $value, $this);


### PR DESCRIPTION
Reverts pull request #47, and implements a better handling of std values by adding options std_show and std_mark in order to let developer decide if he wants to show the std values or not and also put a mark to visually indicate fields using std values.

This commit also fixes a bug in pull request # 48: the filter parameters where in the wrong order, since the first parameter must be the default value to return.
