### PR TITLE
Reverting and fixing example change for Google fonts chooser

### DIFF
--- a/options.php
+++ b/options.php
@@ -213,11 +213,11 @@ function setup_framework_options() {
 			array(
 				'id' => 'font_awesome_info',
 				'type' => 'raw_html',
-				'html' => '<h3 style="text-align: center; border-bottom: none;">Redux Framework is now powered by <a href="http://fortawesome.github.com/Font-Awesome/">Font Awesome</a>!</h3><h4 style="text-align: center; font-size: 1.3em;">What does this mean to you?</h4>
+				'html' => '<h3 style="text-align: center; border-bottom: none;">Redux Framework is now powered by <a href="http://fortawesome.github.com/Font-Awesome/" target="_blank">Font Awesome</a>!</h3><h4 style="text-align: center; font-size: 1.3em;">What does this mean to you?</h4>
 				<p>Well for one thing it means that Redux as a whole is a much leaner package than it used to be. Those annoying icons took up a <strong>lot</strong> of unnecessary space. Additionally, it means you have a lot more flexibility with your icons.
 				Each icon field has an option for you to define custom classes. These are defined on an icon-by-icon basis and can be Font Awesome specific classes or your own custom ones. Want to see why this is so cool? Keep reading!</p>
 				<br/><span style="font-weight: bold; text-decoration: underline;">The Icons</span><p>There&apos;s just too many to list! <a href="http://fortawesome.github.com/Font-Awesome/#icons-new" target="_blank">Click here</a> for the official list.</p>
-				<br/><span style="font-weight: bold; text-decoration: underline;">The Classes</span><p>There are just as many built-in classes as icons! <a href="http://fortawesome.github.com/Font-Awesome/#examples">Click here</a> for a few examples.</p>
+				<br/><span style="font-weight: bold; text-decoration: underline;">The Classes</span><p>There are just as many built-in classes as icons! <a href="http://fortawesome.github.com/Font-Awesome/#examples" target="_blank">Click here</a> for a few examples.</p>
 				<br/><span style="font-weight: bold; text-decoration: underline;">Anything Else?</span><p>Yep! Because it&apos;s iconfont and not image based, you can apply pretty much any CSS to an icon!</p>'
 			)
 		)

--- a/options/fields/google_webfonts/field_google_webfonts.php
+++ b/options/fields/google_webfonts/field_google_webfonts.php
@@ -26,6 +26,8 @@ class Redux_Options_google_webfonts {
 
         echo '<input type="text" id="' . $this->field['id'] . '" name="' . $this->args['opt_name'] . '[' . $this->field['id'] . ']" class="font"  ' . 'value="' . esc_attr($this->value) . '" />';
 
+	echo '<h3 id="' . $this->field['id'] . '" class="example">Lorem Ipsum is simply dummy text</h3>';
+
         echo (isset($this->field['desc']) && !empty($this->field['desc'])) ? ' <span class="description">' . $this->field['desc'] . '</span>' : '';
     }
 

--- a/options/fields/google_webfonts/jquery.fontselect.js
+++ b/options/fields/google_webfonts/jquery.fontselect.js
@@ -1,6 +1,9 @@
 jQuery(document).ready(function ($) {
     var googlefont = jQuery('.font').fontselect();
-    fontset(googlefont);
+    
+	jQuery(".font").change(function() {
+		fontset(googlefont);
+	});
 
     function fontset(googlefont) {
         var relid = googlefont.attr('id');


### PR DESCRIPTION
This will fix changing example heading (h3) when changing dropdown for Google fonts select options. And here is screencast how this will look like :) http://screencast.com/t/oCIiWRhhlj5

Also, add target="_blank" for all Font Awesome! links
