### PR TITLE
Rewrote all of the select fields to extend a common class

### DIFF
--- a/options.php
+++ b/options.php
@@ -646,6 +646,14 @@ function setup_framework_options() {
                 //'args' => array() // Uses get_post_types()
             ),
             array(
+                'id' => 'post_type_multi_select_demo',
+                'type' => 'post_type_multi_select',
+                'title' => __('Post Type Multi Select Option', Redux_TEXT_DOMAIN), 
+                'sub_desc' => __('No validation can be done on this field type', Redux_TEXT_DOMAIN),
+                'desc' => __('This field creates a multi select menu of all registered post types.', Redux_TEXT_DOMAIN),
+                //'args' => array() // Uses get_post_types()
+            ),
+            array(
                 'id' => 'select_hide_below_demo',
                 'type' => 'select_hide_below',
                 'title' => __('Select Hide Below Option', Redux_TEXT_DOMAIN), 

--- a/options.php
+++ b/options.php
@@ -561,7 +561,7 @@ function setup_framework_options() {
                 'title' => __('Pages Multiple Select Option', Redux_TEXT_DOMAIN), 
                 'sub_desc' => __('No validation can be done on this field type', Redux_TEXT_DOMAIN),
                 'desc' => __('This field creates a multi select menu of all the sites pages.', Redux_TEXT_DOMAIN),
-                'args' => array('number' => '5') // Uses get_pages()
+                'args' => array('number' => '7') // Uses get_pages()
             ),
             array(
                 'id' => 'posts_select_demo',

--- a/options/fields/cats_multi_select/field_cats_multi_select.php
+++ b/options/fields/cats_multi_select/field_cats_multi_select.php
@@ -1,5 +1,6 @@
 <?php
-class Redux_Options_cats_multi_select {
+require_once(dirname(__FILE__).'/../select/'.'field_select.php'); 
+class Redux_Options_cats_multi_select extends Redux_Options_select {
 
     /**
      * Field Constructor.
@@ -12,27 +13,12 @@ class Redux_Options_cats_multi_select {
         $this->field = $field;
 		$this->value = $value;
 		$this->args = $parent->args;
-    }
-
-    /**
-     * Field Render Function.
-     *
-     * Takes the vars and outputs the HTML for the field in the settings
-     *
-     * @since Redux_Options 1.0.0
-    */
-    function render() {
-        $class = (isset($this->field['class'])) ? 'class="' . $this->field['class'] . '" ' : '';
-        echo '<select id="' . $this->field['id'] . '" name="' . $this->args['opt_name'] . '[' . $this->field['id'] . '][]" ' . $class . 'multiple="multiple" >';
-        $args = wp_parse_args($this->field['args'], array());
-        $cats = get_categories($args);
-
-        foreach($cats as $cat) {
-            $selected = (is_array($this->value) && in_array($cat->term_id, $this->value)) ? ' selected="selected"' : '';
-            echo '<option value="' . $cat->term_id . '"' . $selected . '>' . $cat->name . '</option>';
-        }
-
-        echo '</select>';
-        echo (isset($this->field['desc']) && !empty($this->field['desc'])) ? '<br/><span class="description">' . $this->field['desc'] . '</span>' : '';
+		
+        $wp_args = wp_parse_args($this->field['args'], array());
+		$cats = get_categories($wp_args);
+		foreach ($cats as $cat) {
+			$this->field['options'][$cat->term_id] = $cat->name;
+		}
+		$this->field['multiselect'] = true;
     }
 }

--- a/options/fields/cats_select/field_cats_select.php
+++ b/options/fields/cats_select/field_cats_select.php
@@ -1,6 +1,7 @@
 <?php
-class Redux_Options_cats_select {
-    
+require_once(dirname(__FILE__).'/../select/'.'field_select.php'); 
+class Redux_Options_cats_select extends Redux_Options_select {
+
     /**
      * Field Constructor.
      *
@@ -12,26 +13,11 @@ class Redux_Options_cats_select {
         $this->field = $field;
 		$this->value = $value;
 		$this->args = $parent->args;
-    }
-
-    /**
-     * Field Render Function.
-     *
-     * Takes the vars and outputs the HTML for the field in the settings
-     *
-     * @since Redux_Options 1.0.0
-    */
-    function render() {
-        $class = (isset($this->field['class'])) ? 'class="' . $this->field['class'] . '" ' : '';
-        echo '<select id="' . $this->field['id'] . '" name="' . $this->args['opt_name'] . '[' . $this->field['id'] . ']" ' . $class . ' >';
-        $args = wp_parse_args($this->field['args'], array());
-        $cats = get_categories($args);
-
-        foreach($cats as $cat) {
-            echo '<option value="' . $cat->term_id . '"' . selected($this->value, $cat->term_id, false) . '>' . $cat->name . '</option>';
-        }
-
-        echo '</select>';
-        echo (isset($this->field['desc']) && !empty($this->field['desc'])) ? ' <span class="description">' . $this->field['desc'] . '</span>' : '';
+		
+		$wp_args = wp_parse_args($this->field['args'], array());
+		$cats = get_categories($wp_args);
+		foreach ($cats as $cat) {
+			$this->field['options'][$cat->term_id] = $cat->name;
+		}
     }
 }

--- a/options/fields/menu_location_select/field_menu_location_select.php
+++ b/options/fields/menu_location_select/field_menu_location_select.php
@@ -1,5 +1,6 @@
 <?php
-class Redux_Options_menu_location_select {
+require_once(dirname(__FILE__).'/../select/'.'field_select.php'); 
+class Redux_Options_menu_location_select extends Redux_Options_select {
 
     /**
      * Field Constructor.
@@ -12,28 +13,10 @@ class Redux_Options_menu_location_select {
         $this->field = $field;
 		$this->value = $value;
 		$this->args = $parent->args;
-    }
-
-    /**
-     * Field Render Function.
-     *
-     * Takes the vars and outputs the HTML for the field in the settings
-     *
-     * @since Redux_Options 1.0.0
-    */
-    function render() {
-        $class = (isset($this->field['class'])) ? 'class="' . $this->field['class'] . '" ' : '';
+		
         global $_wp_registered_nav_menus;
-
-        echo '<select id="' . $this->field['id'] . '" name="' . $this->args['opt_name'] . '[' . $this->field['id'] . ']" ' . $class . ' >';
-
-        if($_wp_registered_nav_menus) {
-            foreach($_wp_registered_nav_menus as $k => $v) {
-                echo '<option value="' . $k . '"' . selected($this->value, $k, false) . '>' . $v . '</option>';
-            }
-        }
-
-        echo '</select>';
-        echo (isset($this->field['desc']) && !empty($this->field['desc'])) ? ' <span class="description">' . $this->field['desc'] . '</span>' : '';
+		if($_wp_registered_nav_menus) {
+			$this->field['options'] = $_wp_registered_nav_menus;
+		}
     }
 }

--- a/options/fields/menu_select/field_menu_select.php
+++ b/options/fields/menu_select/field_menu_select.php
@@ -1,5 +1,6 @@
 <?php
-class Redux_Options_menu_select {
+require_once(dirname(__FILE__).'/../select/'.'field_select.php'); 
+class Redux_Options_menu_select extends Redux_Options_select  {
 
     /**
      * Field Constructor.
@@ -12,29 +13,12 @@ class Redux_Options_menu_select {
         $this->field = $field;
 		$this->value = $value;
 		$this->args = $parent->args;
-    }
-
-    /**
-     * Field Render Function.
-     *
-     * Takes the vars and outputs the HTML for the field in the settings
-     *
-     * @since Redux_Options 1.0.0
-    */
-    function render() {
-        $class = (isset($this->field['class'])) ? 'class="' . $this->field['class'] . '" ' : '';
-        echo '<select id="' . $this->field['id'] . '" name="' . $this->args['opt_name'] . '[' . $this->field['id'] . ']" ' . $class . ' >';
-        if(!isset($this->field['args'])) { $this->field['args'] = array(); }
-        $args = wp_parse_args($this->field['args'], array());
-
+		
         $menus = wp_get_nav_menus($args);
         if($menus) {
             foreach ($menus as $menu) {
-                echo '<option value="' . $menu->term_id . '"' . selected($this->value, $menu->term_id, false) . '>' . $menu->name . '</option>';
-            }
-        }
-
-        echo '</select>';
-        echo (isset($this->field['desc']) && !empty($this->field['desc'])) ? ' <span class="description">' . $this->field['desc'] . '</span>' : '';
+				$this->field['options'][$menu->term_id] = $menu->name;
+			}
+		}
     }
 }

--- a/options/fields/multi_select/field_multi_select.php
+++ b/options/fields/multi_select/field_multi_select.php
@@ -1,5 +1,6 @@
 <?php
-class Redux_Options_multi_select {
+require_once(dirname(__FILE__).'/../select/'.'field_select.php'); 
+class Redux_Options_multi_select extends Redux_Options_select {
 
     /**
      * Field Constructor.
@@ -12,23 +13,6 @@ class Redux_Options_multi_select {
         $this->field = $field;
 		$this->value = $value;
 		$this->args = $parent->args;
-    }
-
-    /**
-     * Field Render Function.
-     *
-     * Takes the vars and outputs the HTML for the field in the settings
-     *
-     * @since Redux_Options 1.0.0
-    */
-    function render() {
-        $class = (isset($this->field['class'])) ? 'class="' . $this->field['class'] . '" ' : '';
-        echo '<select id="' . $this->field['id'] . '" name="' . $this->args['opt_name'] . '[' . $this->field['id'] . '][]" ' . $class . 'multiple="multiple" rows="6" >';
-        foreach($this->field['options'] as $k => $v) {
-            $selected = (is_array($this->value) && in_array($k, $this->value)) ? ' selected="selected"' : '';
-            echo '<option value="' . $k . '"' . $selected . '>' . $v . '</option>';
-        }
-        echo '</select>';
-        echo (isset($this->field['desc']) && !empty($this->field['desc'])) ? '<br/><span class="description">' . $this->field['desc'] . '</span>' : '';
+		$this->field['multiselect'] = true;
     }
 }

--- a/options/fields/pages_multi_select/field_pages_multi_select.php
+++ b/options/fields/pages_multi_select/field_pages_multi_select.php
@@ -1,5 +1,6 @@
 <?php
-class Redux_Options_pages_multi_select {
+require_once(dirname(__FILE__).'/../select/'.'field_select.php'); 
+class Redux_Options_pages_multi_select extends Redux_Options_select {
 
     /**
      * Field Constructor.
@@ -12,27 +13,12 @@ class Redux_Options_pages_multi_select {
         $this->field = $field;
 		$this->value = $value;
 		$this->args = $parent->args;
-    }
-
-    /**
-     * Field Render Function.
-     *
-     * Takes the vars and outputs the HTML for the field in the settings
-     *
-     * @since Redux_Options 1.0.0
-    */
-    function render() {
-        $class = (isset($this->field['class'])) ? 'class="' . $this->field['class'] . '" ' : '';
-        echo '<select id="' . $this->field['id'] . '" name="' . $this->args['opt_name'] . '[' . $this->field['id'] . '][]" ' . $class . 'multiple="multiple" >';
-        $args = wp_parse_args($this->field['args'], array());
-        $pages = get_pages($args);
-
-        foreach ($pages as $page) {
-            $selected = (is_array($this->value) && in_array($page->ID, $this->value)) ? ' selected="selected"' : '';
-            echo '<option value="' . $page->ID . '"' . $selected . '>' . $page->post_title . '</option>';
-        }
-
-        echo '</select>';
-        echo (isset($this->field['desc']) && !empty($this->field['desc'])) ? '<br/><span class="description">' . $this->field['desc'] . '</span>' : '';
+		
+		$wp_args = wp_parse_args($this->field['args'], array());
+		$posts = get_pages($wp_args);
+		foreach ($posts as $post) {
+			$this->field['options'][$post->ID] = $post->post_title;
+		}
+		$this->field['multiselect'] = true;
     }
 }

--- a/options/fields/pages_select/field_pages_select.php
+++ b/options/fields/pages_select/field_pages_select.php
@@ -1,5 +1,6 @@
 <?php
-class Redux_Options_pages_select {
+require_once(dirname(__FILE__).'/../select/'.'field_select.php'); 
+class Redux_Options_pages_select extends Redux_Options_select {
 
     /**
      * Field Constructor.
@@ -12,26 +13,11 @@ class Redux_Options_pages_select {
         $this->field = $field;
 		$this->value = $value;
 		$this->args = $parent->args;
-    }
-
-    /**
-     * Field Render Function.
-     *
-     * Takes the vars and outputs the HTML for the field in the settings
-     *
-     * @since Redux_Options 1.0.0
-    */
-    function render() {
-        $class = (isset($this->field['class'])) ? 'class="' . $this->field['class'] . '" ' : '';
-        echo '<select id="' . $this->field['id'] . '" name="' . $this->args['opt_name'] . '[' . $this->field['id'] . ']" ' . $class . 'rows="6" >';
-        $args = wp_parse_args($this->field['args'], array());
-        $pages = get_pages($args);
-
-        foreach($pages as $page) {
-            echo '<option value="' . $page->ID . '"' . selected($this->value, $page->ID, false) . '>' . $page->post_title . '</option>';
-        }
-
-        echo '</select>';
-        echo (isset($this->field['desc']) && !empty($this->field['desc'])) ? ' <span class="description">' . $this->field['desc'] . '</span>' : '';
+		
+		$wp_args = wp_parse_args($this->field['args'], array());
+		$posts = get_pages($wp_args);
+		foreach ($posts as $post) {
+			$this->field['options'][$post->ID] = $post->post_title;
+		}
     }
 }

--- a/options/fields/post_type_multi_select/field_post_type_multi_select.php
+++ b/options/fields/post_type_multi_select/field_post_type_multi_select.php
@@ -1,5 +1,6 @@
 <?php
-class Redux_Options_post_type_multi_select {
+require_once(dirname(__FILE__).'/../select/'.'field_select.php'); 
+class Redux_Options_post_type_multi_select extends Redux_Options_select {
 
     /**
      * Field Constructor.
@@ -12,28 +13,9 @@ class Redux_Options_post_type_multi_select {
         $this->field = $field;
 		$this->value = $value;
 		$this->args = $parent->args;
-    }
-
-    /**
-     * Field Render Function.
-     *
-     * Takes the vars and outputs the HTML for the field in the settings
-     *
-     * @since Redux_Options 1.0.0
-    */
-    function render() {
-        $class = (isset($this->field['class'])) ? 'class="' . $this->field['class'] . '" ' : '';
-        echo '<select id="' . $this->field['id'] . '" name="' . $this->args['opt_name'] . '[' . $this->field['id'] . '][]" ' . $class . 'multiple="multiple" >';
-        if(!isset($this->field['args'])) { $this->field['args'] = array(); }
-        $args = wp_parse_args($this->field['args'], array('public' => true));
-        $post_types = get_post_types($args, 'object'); 
-
-        foreach($post_types as $k => $post_type) {
-            $selected = (is_array($this->value) && in_array($k, $this->value)) ? ' selected="selected"' : '';
-            echo '<option value="' . $k . '"' . $selected . '>' . $post_type->labels->name . '</option>';
-        }
-
-        echo '</select>';
-        echo (isset($this->field['desc']) && !empty($this->field['desc'])) ? ' <span class="description">' . $this->field['desc'] . '</span>' : '';
+		
+        $wp_args = wp_parse_args($this->field['args'], array('public' => true));
+		$this->field['options'] = get_post_types($wp_args, 'names');
+		$this->field['multiselect'] = true;
     }
 }

--- a/options/fields/post_type_multi_select/field_post_type_multi_select.php
+++ b/options/fields/post_type_multi_select/field_post_type_multi_select.php
@@ -1,0 +1,39 @@
+<?php
+class Redux_Options_post_type_multi_select {
+
+    /**
+     * Field Constructor.
+     *
+     * Required - must call the parent constructor, then assign field and value to vars, and obviously call the render field function
+     *
+     * @since Redux_Options 1.0.0
+    */
+    function __construct($field = array(), $value ='', $parent) {
+        $this->field = $field;
+		$this->value = $value;
+		$this->args = $parent->args;
+    }
+
+    /**
+     * Field Render Function.
+     *
+     * Takes the vars and outputs the HTML for the field in the settings
+     *
+     * @since Redux_Options 1.0.0
+    */
+    function render() {
+        $class = (isset($this->field['class'])) ? 'class="' . $this->field['class'] . '" ' : '';
+        echo '<select id="' . $this->field['id'] . '" name="' . $this->args['opt_name'] . '[' . $this->field['id'] . '][]" ' . $class . 'multiple="multiple" >';
+        if(!isset($this->field['args'])) { $this->field['args'] = array(); }
+        $args = wp_parse_args($this->field['args'], array('public' => true));
+        $post_types = get_post_types($args, 'object'); 
+
+        foreach($post_types as $k => $post_type) {
+            $selected = (is_array($this->value) && in_array($k, $this->value)) ? ' selected="selected"' : '';
+            echo '<option value="' . $k . '"' . $selected . '>' . $post_type->labels->name . '</option>';
+        }
+
+        echo '</select>';
+        echo (isset($this->field['desc']) && !empty($this->field['desc'])) ? ' <span class="description">' . $this->field['desc'] . '</span>' : '';
+    }
+}

--- a/options/fields/post_type_select/field_post_type_select.php
+++ b/options/fields/post_type_select/field_post_type_select.php
@@ -1,5 +1,6 @@
 <?php
-class Redux_Options_post_type_select {
+require_once(dirname(__FILE__).'/../select/'.'field_select.php'); 
+class Redux_Options_post_type_select extends Redux_Options_select {
 
     /**
      * Field Constructor.
@@ -12,27 +13,8 @@ class Redux_Options_post_type_select {
         $this->field = $field;
 		$this->value = $value;
 		$this->args = $parent->args;
-    }
-
-    /**
-     * Field Render Function.
-     *
-     * Takes the vars and outputs the HTML for the field in the settings
-     *
-     * @since Redux_Options 1.0.0
-    */
-    function render() {
-        $class = (isset($this->field['class'])) ? 'class="' . $this->field['class'] . '" ' : '';
-        echo '<select id="' . $this->field['id'] . '" name="' . $this->args['opt_name'] . '[' . $this->field['id'] . ']" ' . $class . ' >';
-        if(!isset($this->field['args'])) { $this->field['args'] = array(); }
-        $args = wp_parse_args($this->field['args'], array('public' => true));
-        $post_types = get_post_types($args, 'object'); 
-
-        foreach($post_types as $k => $post_type) {
-            echo '<option value="' . $k . '"' . selected($this->value, $k, false) . '>' . $post_type->labels->name . '</option>';
-        }
-
-        echo '</select>';
-        echo (isset($this->field['desc']) && !empty($this->field['desc'])) ? ' <span class="description">' . $this->field['desc'] . '</span>' : '';
+		
+        $wp_args = wp_parse_args($this->field['args'], array('public' => true));
+		$this->field['options'] = get_post_types($wp_args, 'names');
     }
 }

--- a/options/fields/posts_multi_select/field_posts_multi_select.php
+++ b/options/fields/posts_multi_select/field_posts_multi_select.php
@@ -1,5 +1,6 @@
 <?php
-class Redux_Options_posts_multi_select {
+require_once(dirname(__FILE__).'/../select/'.'field_select.php'); 
+class Redux_Options_posts_multi_select extends Redux_Options_select {
 
     /**
      * Field Constructor.
@@ -12,27 +13,12 @@ class Redux_Options_posts_multi_select {
         $this->field = $field;
 		$this->value = $value;
 		$this->args = $parent->args;
-    }
-
-    /**
-     * Field Render Function.
-     *
-     * Takes the vars and outputs the HTML for the field in the settings
-     *
-     * @since Redux_Options 1.0.0
-    */
-    function render() {
-        $class = (isset($this->field['class'])) ? 'class="' . $this->field['class'] . '" ' : '';
-        echo '<select id="' . $this->field['id'] . '" name="' . $this->args['opt_name'] . '[' . $this->field['id'] . '][]" ' . $class . 'multiple="multiple" >';
-        $args = wp_parse_args($this->field['args'], array('numberposts' => '-1'));
-        $posts = get_posts($args);
-
-        foreach($posts as $post) {
-            $selected = (is_array($this->value) && in_array($post->ID, $this->value)) ? ' selected="selected"' : '';
-            echo '<option value="' . $post->ID . '"' . $selected . '>' . $post->post_title . '</option>';
-        }
-
-        echo '</select>';
-        echo (isset($this->field['desc']) && !empty($this->field['desc'])) ? '<br/><span class="description">' . $this->field['desc'] . '</span>' : '';
+		
+        $wp_args = wp_parse_args($this->field['args'], array('numberposts' => '-1'));
+		$posts = get_posts($wp_args);
+		foreach ($posts as $post) {
+			$this->field['options'][$post->ID] = $post->post_title;
+		}
+		$this->field['multiselect'] = true;
     }
 }

--- a/options/fields/posts_select/field_posts_select.php
+++ b/options/fields/posts_select/field_posts_select.php
@@ -1,5 +1,6 @@
 <?php
-class Redux_Options_posts_select {
+require_once(dirname(__FILE__).'/../select/'.'field_select.php'); 
+class Redux_Options_posts_select extends Redux_Options_select {
 
     /**
      * Field Constructor.
@@ -12,26 +13,11 @@ class Redux_Options_posts_select {
         $this->field = $field;
 		$this->value = $value;
 		$this->args = $parent->args;
-    }
-
-    /**
-     * Field Render Function.
-     *
-     * Takes the vars and outputs the HTML for the field in the settings
-     *
-     * @since Redux_Options 1.0.0
-    */
-    function render() {
-        $class = (isset($this->field['class'])) ? 'class="' . $this->field['class'] . '" ' : '';
-        echo '<select id="' . $this->field['id'] . '" name="' . $this->args['opt_name'] . '[' . $this->field['id'] . ']" ' . $class . ' >';
-        $args = wp_parse_args($this->field['args'], array('numberposts' => '-1'));
-        $posts = get_posts($args);
-
-        foreach($posts as $post) {
-            echo '<option value="' . $post->ID . '"' . selected($this->value, $post->ID, false) . '>' . $post->post_title . '</option>';
-        }
-
-        echo '</select>';
-        echo (isset($this->field['desc']) && !empty($this->field['desc'])) ? ' <span class="description">' . $this->field['desc'] . '</span>' : '';
+		
+		$wp_args = wp_parse_args($this->field['args'], array('numberposts' => '-1'));
+		$posts = get_posts($wp_args);
+		foreach ($posts as $post) {
+			$this->field['options'][$post->ID] = $post->post_title;
+		}
     }
 }

--- a/options/fields/select/field_select.php
+++ b/options/fields/select/field_select.php
@@ -23,11 +23,17 @@ class Redux_Options_select {
     */
     function render() {
         $class = (isset($this->field['class'])) ? 'class="' . $this->field['class'] . '" ' : '';
-        echo '<select id="' . $this->field['id'] . '" name="' . $this->args['opt_name'] . '[' . $this->field['id'] . ']" ' . $class . 'rows="6" >';
+		if ($this->field['multiselect']) {
+			$array_dims = '[]';
+			$multiselect = ' multiple="multiple"';
+			$multiselect .= ' size="' . (isset($this->field['rows']) ? $this->field['rows'] : '6') .'"'; //'rows' is the number of rows to display on multi-select
+		}
+        echo '<select id="' . $this->field['id'] . '" name="' . $this->args['opt_name'] . '[' . $this->field['id'] . ']' . $array_dims . '" ' . $class . $multiselect . ' >';
         foreach($this->field['options'] as $k => $v) {
-            echo '<option value="' . $k . '" ' . selected($this->value, $k, false) . '>' . $v . '</option>';
+            $selected = (is_array($this->value) && in_array($k, $this->value) || $this->value == $k) ? ' selected="selected"' : '';
+            echo '<option value="' . $k . '"' . $selected . '>' . $v . '</option>';
         }
         echo '</select>';
-        echo (isset($this->field['desc']) && !empty($this->field['desc'])) ? ' <span class="description">' . $this->field['desc'] . '</span>' : '';
+        echo (isset($this->field['desc']) && !empty($this->field['desc'])) ? '<br/><span class="description">' . $this->field['desc'] . '</span>' : '';
     }
 }

--- a/options/fields/tags_multi_select/field_tags_multi_select.php
+++ b/options/fields/tags_multi_select/field_tags_multi_select.php
@@ -1,5 +1,6 @@
 <?php
-class Redux_Options_tags_multi_select {
+require_once(dirname(__FILE__).'/../select/'.'field_select.php'); 
+class Redux_Options_tags_multi_select extends Redux_Options_select {
 
     /**
      * Field Constructor.
@@ -12,25 +13,12 @@ class Redux_Options_tags_multi_select {
         $this->field = $field;
 		$this->value = $value;
 		$this->args = $parent->args;
-    }//function
-
-    /**
-     * Field Render Function.
-     *
-     * Takes the vars and outputs the HTML for the field in the settings
-     *
-     * @since Redux_Options 1.0.0
-    */
-    function render() {
-        $class = (isset($this->field['class'])) ? 'class="' . $this->field['class'] . '" ' : '';
-        echo '<select id="' . $this->field['id'] . '" name="' . $this->args['opt_name'] . '[' . $this->field['id'] . '][]" ' . $class . 'multiple="multiple" >';
-        $args = wp_parse_args($this->field['args'], array());
-        $tags = get_tags($args);
-        foreach($tags as $tag) {
-            $selected = (is_array($this->value) && in_array($tag->term_id, $this->value)) ? ' selected="selected"' : '';
-            echo '<option value="' . $tag->term_id . '"' . $selected . '>' . $tag->name . '</option>';
-        }
-        echo '</select>';
-        echo (isset($this->field['desc']) && !empty($this->field['desc'])) ? '<br/><span class="description">' . $this->field['desc'] . '</span>' : '';
+		
+		$wp_args = wp_parse_args($this->field['args'], array());
+		$tags = get_tags($wp_args);
+		foreach ($tags as $tag) {
+			$this->field['options'][$tag->term_id] = $tag->name;
+		}
+		$this->field['multiselect'] = true;
     }
 }

--- a/options/fields/tags_select/field_tags_select.php
+++ b/options/fields/tags_select/field_tags_select.php
@@ -1,5 +1,6 @@
 <?php
-class Redux_Options_tags_select {
+require_once(dirname(__FILE__).'/../select/'.'field_select.php'); 
+class Redux_Options_tags_select extends Redux_Options_select {
 
     /**
      * Field Constructor.
@@ -12,24 +13,11 @@ class Redux_Options_tags_select {
         $this->field = $field;
 		$this->value = $value;
 		$this->args = $parent->args;
-    }
-
-    /**
-     * Field Render Function.
-     *
-     * Takes the vars and outputs the HTML for the field in the settings
-     *
-     * @since Redux_Options 1.0.0
-    */
-    function render() {
-        $class = (isset($this->field['class'])) ? 'class="' . $this->field['class'] . '" ' : '';
-        echo '<select id="' . $this->field['id'] . '" name="' . $this->args['opt_name'] . '[' . $this->field['id'] . ']" ' . $class . ' >';
-        $args = wp_parse_args($this->field['args'], array());
-        $tags = get_tags($args); 
-        foreach($tags as $tag) {
-            echo '<option value="' . $tag->term_id . '"' . selected($this->value, $tag->term_id, false) . '>' . $tag->name . '</option>';
-        }
-        echo '</select>';
-        echo (isset($this->field['desc']) && !empty($this->field['desc'])) ? ' <span class="description">' . $this->field['desc'] . '</span>' : '';
+		
+		$wp_args = wp_parse_args($this->field['args'], array());
+		$tags = get_tags($wp_args);
+		foreach ($tags as $tag) {
+			$this->field['options'][$tag->term_id] = $tag->name;
+		}
     }
 }

--- a/options/fields/taxonomy_multi_select/field_taxonomy_multi_select.php
+++ b/options/fields/taxonomy_multi_select/field_taxonomy_multi_select.php
@@ -1,5 +1,6 @@
 <?php
-class Redux_Options_taxonomy_multi_select {
+require_once(dirname(__FILE__).'/../select/'.'field_select.php'); 
+class Redux_Options_taxonomy_multi_select extends Redux_Options_select {
 
     /**
      * Field Constructor.
@@ -7,30 +8,14 @@ class Redux_Options_taxonomy_multi_select {
      * Required - must call the parent constructor, then assign field and value to vars, and obviously call the render field function
      *
      * @since Redux_Options 1.0.0
-     */
+    */
     function __construct($field = array(), $value ='', $parent) {
         $this->field = $field;
-        $this->value = $value;
-        $this->args = $parent->args;
-    }//function
-
-    /**
-     * Field Render Function.
-     *
-     * Takes the vars and outputs the HTML for the field in the settings
-     *
-     * @since Redux_Options 1.0.0
-     */
-    function render() {
-        $class = (isset($this->field['class'])) ? 'class="' . $this->field['class'] . '" ' : '';
-        echo '<select id="' . $this->field['id'] . '" name="' . $this->args['opt_name'] . '[' . $this->field['id'] . '][]" ' . $class . 'multiple="multiple" >';
-        $args = wp_parse_args($this->field['args'], array());
-        $taxonomies = get_taxonomies($args, 'object');
-        foreach($taxonomies as $taxonomy) {
-            $selected = (is_array($this->value) && in_array($taxonomy->name, $this->value)) ? ' selected="selected"' : '';
-            echo '<option value="' . $taxonomy->name . '"' . $selected . '>' . $taxonomy->name . '</option>';
-        }
-        echo '</select>';
-        echo (isset($this->field['desc']) && !empty($this->field['desc'])) ? '<br/><span class="description">' . $this->field['desc'] . '</span>' : '';
+		$this->value = $value;
+		$this->args = $parent->args;
+		
+		$wp_args = wp_parse_args($this->field['args'], array());
+		$this->field['options'] = get_taxonomies($args, 'names');
+		$this->field['multiselect'] = true;
     }
 }


### PR DESCRIPTION
Made the "select" field a base class for all of the other select fields (both drop-downs and multi-selects). I wanted to make the code reusable and and to add consistency to the rendering of all of the different select/multi-select fields.

Also added an attribute "multiselect" to the base class, which allows a drop-down or multi-select menu to be chosen for ANY of the select fields by simply adding a new attribute in options.php. This reduces the number of additional field classes that need to be added for every different type of select list. So instead of tags select and tags select multi, in theory there is only the need for a single tags select class and then the user sets the multiselect attribute to true or false depending on whether a dropdown or multi-select is desired.

Granted at this point this is rather moot since there are dropdown and multi-select fields for most everything...but it's still good practice in case the base class needs to be modified for any reason (e.g. styling).

NOTE: I didn't include the extra <br /> tag between the list and the description for multi-select lists, but this is a trivial modification on the base select class that I might add later.
